### PR TITLE
Remove redundant explicit dependency

### DIFF
--- a/embed-spring-boot-27/pom.xml
+++ b/embed-spring-boot-27/pom.xml
@@ -25,12 +25,6 @@
     <dependencies>
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
-            <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>${embedded.mongo.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo.spring27x</artifactId>
             <version>4.9.3</version>
             <scope>test</scope>


### PR DESCRIPTION
`de.flapdoodle.embed` is still listed in the `spring-boot-dependencies` referenced by `spring-boot-starter-parent` (at least from what i can confirm for v2.7.17). Therefore the simple property override `<embedded-mongo.version>4.9.3</embedded-mongo.version>` is enough to successfully set up `de.flapdoodle.embed.mongo.spring27x` in Spring Boot 2.7.x.