### PR TITLE
Improvement: Update Spring Boot 4.x Test to check the existence of Wrapped Mongod Bean

### DIFF
--- a/embed-spring-boot-40/pom.xml
+++ b/embed-spring-boot-40/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo.spring4x</artifactId>
-            <version>4.22.0</version>
+            <version>4.22.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/embed-spring-boot-40/src/test/java/example/ExampleIT.java
+++ b/embed-spring-boot-40/src/test/java/example/ExampleIT.java
@@ -1,31 +1,30 @@
 package example;
 
 import com.mongodb.assertions.Assertions;
+import de.flapdoodle.embed.mongo.spring.autoconfigure.MongodWrapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.data.mongodb.test.autoconfigure.AutoConfigureDataMongo;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.data.mongodb.test.autoconfigure.DataMongoTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@AutoConfigureDataMongo
-@SpringBootTest()
-@EnableAutoConfiguration
-@DirtiesContext
+@DataMongoTest()
+@ExtendWith(SpringExtension.class)
 class ExampleIT {
     @Test
-    void example(@Autowired final MongoTemplate mongoTemplate) {
+    void example(@Autowired final MongoTemplate mongoTemplate, @Autowired final ApplicationContext applicationContext) {
         Assertions.assertNotNull(mongoTemplate.getDb());
         ArrayList<String> collectionNames = mongoTemplate.getDb()
           .listCollectionNames()
           .into(new ArrayList<>());
         assertThat(collectionNames).isEmpty();
+        assertThat(applicationContext.getBeanNamesForType(MongodWrapper.class)).isNotEmpty();
+        assertThat(applicationContext.getBean(MongodWrapper.class)).isNotNull();
     }
 }


### PR DESCRIPTION
Builds on top of https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.spring/pull/78

This PR reverts the extra changes in [ExampleIT.java](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo.canary/blob/main/embed-spring-boot-40/src/test/java/example/ExampleIT.java) to match the other usages and also adds a couple asserts to ensure that Embedded Mongo is being used

**Please recheck and update the version as needed**, the changes in [`embed-spring-boot-40/pom.xml`](https://github.com/ntungare/de.flapdoodle.embed.mongo.canary/blob/fix-auto-config-for-spring-boot4/embed-spring-boot-40/pom.xml#L30-L35) are only for my local testing via maven